### PR TITLE
Add developer docs section

### DIFF
--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -1,0 +1,34 @@
+.. _developer-overview:
+
+Developer Overview
+==================
+
+This section provides a high level look at the ``hckr`` project for new contributors.
+
+Repository Structure
+--------------------
+
+``hckr`` is organized as a Python package with the command line interface under
+``src/hckr`` and Sphinx documentation under ``docs``.  The most important
+directories are:
+
+* ``src/hckr/cli`` - Click command definitions
+* ``src/hckr/utils`` - shared helper modules
+* ``tests`` - unit tests using ``pytest``
+* ``docs`` - documentation sources
+
+Entry Point
+-----------
+
+The CLI entry point is implemented in ``src/hckr/cli/__init__.py``.  Each
+subcommand (``config``, ``cron``, ``crypto`` and others) is defined in its own
+module within ``src/hckr/cli`` and added to the top level ``cli`` group.
+
+Next Steps
+----------
+
+* Run ``hckr --help`` to explore available commands.
+* Browse the source files in ``src/hckr`` to see how commands and utilities are
+  implemented.
+* Read tests in ``tests`` for examples of expected behaviour.
+* Review this documentation under ``docs`` to learn about individual commands.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,3 +33,10 @@
 
    commands/index
 
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Developer Guide
+   :hidden:
+
+   developer/index


### PR DESCRIPTION
## Summary
- document repository overview for new contributors
- link Developer Guide from documentation homepage

## Testing
- `pip install -q rich click click-repl croniter cron-descriptor cryptography Faker pandas openpyxl xlrd pyarrow fastavro sqlacodegen yaspin speedtest-cli kubernetes sqlalchemy`
- `pip install -q requests packaging psycopg2-binary pymysql snowflake-sqlalchemy sentry-sdk`
- `PYTHONPATH=$PWD/src pytest -q` *(fails: HTTP Error 403 from speedtest.net)*

------
https://chatgpt.com/codex/tasks/task_e_685049413ae88327bec6af64b3ab7245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new developer overview page to guide new contributors on project structure and next steps.
  - Updated the documentation index to include a hidden "Developer Guide" section for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->